### PR TITLE
Restrict au model to "JAANET"

### DIFF
--- a/mexca/video/extraction.py
+++ b/mexca/video/extraction.py
@@ -2,12 +2,7 @@
 Extract facial features such as landmarks and action units.
 """
 
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Tuple
-from typing import Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 import cv2
 import feat
 import numpy as np
@@ -196,8 +191,8 @@ class FaceExtractor:
     @staticmethod
     def compute_centroids(
         embs: np.ndarray,
-        labels: List[Union[str, int]]
-    ) -> Tuple[List[float], Dict[str, int]]:
+        labels: List[Union[str, int, float]]
+    ) -> Tuple[List[float], Dict[Union[str, int, float], int]]:
         """ Compute embeddings' centroids
 
         Parameters

--- a/mexca/video/extraction.py
+++ b/mexca/video/extraction.py
@@ -72,23 +72,14 @@ class FaceExtractor:
             pretrained='vggface2'
         ).eval()
         self.cluster = SpectralClusterer(**clargs)
-        self.pyfeat = feat.detector.Detector(
-            au_model=au_model,
-            landmark_model=landmark_model
-        )
 
-
-    @property
-    def pyfeat(self) -> feat.detector.Detector:
-        return self._pyfeat
-
-
-    @pyfeat.setter
-    def pyfeat(self, new_pyfeat: feat.detector.Detector):
-        if new_pyfeat.info['au_model'] == 'jaanet':
-            self._pyfeat = new_pyfeat
-        else:
+        if au_model.lower() != 'jaanet':
             raise ValueError('Only the "JAANET" model is available for AU detection')
+        else:
+            self.pyfeat = feat.detector.Detector(
+                au_model=au_model,
+                landmark_model=landmark_model
+            )
 
 
     def detect(self, frame: np.ndarray) -> Tuple[torch.Tensor, np.ndarray, np.ndarray]:

--- a/tests/video/test_video_extraction.py
+++ b/tests/video/test_video_extraction.py
@@ -20,18 +20,15 @@ class TestFaceExtractor:
         features = json.loads(file.read())
 
 
-    def test_properties(self):
-        with pytest.raises(TypeError):
-            self.extractor.mtcnn = 3.0
+    def test_au_detector(self):
+        with pytest.raises(ValueError):
+            FaceExtractor(min_clusters=1, max_clusters=4, au_model='svm')
 
-        with pytest.raises(TypeError):
-            self.extractor.resnet = 3.0
+        with pytest.raises(ValueError):
+            FaceExtractor(min_clusters=1, max_clusters=4, au_model='logistic')
 
-        with pytest.raises(TypeError):
-            self.extractor.pyfeat = False
-
-        with pytest.raises(TypeError):
-            self.extractor.cluster = 'k'
+        with pytest.raises(ValueError):
+            FaceExtractor(min_clusters=1, max_clusters=4, au_model='rf')
 
 
     def test_detect(self):
@@ -83,22 +80,9 @@ class TestFaceExtractor:
             assert np.array(features['face_aus']).shape == np.array(self.features['face_aus']).shape
 
 
-    def test_check_skip_frames(self):
-        with pytest.raises(ValueError):
-            self.extractor.check_skip_frames(-1)
-
-        with pytest.raises(TypeError):
-            self.extractor.check_skip_frames('k')
-
-
-    # @pytest.mark.skipif(
-    #    platform.system() == 'Windows',
-    #    reason='VMs run out of memory on windows'
-    # )
-
     def test_apply(self): # Tests JAANET AU model
-        with pytest.raises(TypeError):
-            features = self.extractor.apply(self.filepath, show_progress='k')
+        with pytest.raises(ValueError):
+            features = self.extractor.apply(self.filepath, skip_frames=-1, show_progress=False)
 
         with pytest.raises(SkipFramesError):
             features = self.extractor.apply(self.filepath, skip_frames=10, show_progress=False)
@@ -112,7 +96,8 @@ class TestFaceExtractor:
         assert np.array(features['face_landmarks']).shape == np.array(self.features['face_landmarks']).shape
         assert np.array(features['face_aus']).shape == np.array(self.features['face_aus']).shape
 
-    @pytest.mark.skip(
+
+    @pytest.mark.xfail(
         reason='pyfeat currently does not support this model'
     )
     def test_pyfeat_svm(self): # Tests SVM AU model
@@ -122,7 +107,7 @@ class TestFaceExtractor:
         assert np.array(features['face_aus']).shape == np.array(self.features['face_aus_svm']).shape
 
 
-    @pytest.mark.skip(
+    @pytest.mark.xfail(
         reason='pyfeat currently does not support this model'
     )
     def test_pyfeat_logistic(self): # Tests logistic AU model
@@ -130,6 +115,7 @@ class TestFaceExtractor:
         features = svm_extractor.apply(self.filepath, show_progress=False)
 
         assert np.array(features['face_aus']).shape == np.array(self.features['face_aus_logistic']).shape
+
 
     def test_compute_centroids(self):
         # create two array embeddings


### PR DESCRIPTION
Fixes Nlesc-team/Sushi#346

Restricts the choices for pretrained AU detection models to 'JAANET'. The `FaceExtractor` class returns a `ValueError` now if a different model is chosen when instantiated. I did not remove the `au_model` argument in general because the other models might be available again in a future release.

Also updates the tests and adds type annotations to the `mexca/video/extraction.py` code (see #31).