### PR TITLE
Add weekly cron schedule and enable linting workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,48 @@
 name: Python package
 
 on:
+  workflow_dispatch: # For manual triggering
   push:
     branches:
     - main
   pull_request:
     branches:
     - main
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
-  build:
+  lint: # Check code quality and if installation works first 
+    name: Linting build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download libsndfile
+        run: |
+          sudo apt-get install libsndfile1
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.9
+      - name: Python info
+        shell: bash -l {0}
+        run: |
+          which python3
+          python3 --version
+      - name: Upgrade pip and install dependencies
+        run: |
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install .[dev]
+      - name: Check style against standards using prospector
+        run: prospector
+      - name: Check import order
+        run: isort --check-only mexca --diff
+
+  build: # Then test for all OS and Python versions
     name: Build for (${{ matrix.python-version }}, ${{ matrix.os }})
+    needs: [lint]
     runs-on: ${{ matrix.os }}
     env:
       HDF5_DISABLE_VERSION_CHECK: 1
@@ -48,31 +80,3 @@ jobs:
         run: pytest -vv -E runner
       - name: Verify that we can build the package
         run: python3 setup.py sdist bdist_wheel
-
-  # lint:
-  #   name: Linting build
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Download libsndfile
-  #       run: |
-  #         sudo apt-get install libsndfile1
-  #     - name: Set up Python 3.9
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: 3.9
-  #     - name: Python info
-  #       shell: bash -l {0}
-  #       run: |
-  #         which python3
-  #         python3 --version
-  #     - name: Upgrade pip and install dependencies
-  #       run: |
-  #         python3 -m pip install --upgrade pip setuptools wheel
-  #         python3 -m pip install .[dev]
-  #     - name: Check style against standards using prospector
-  #       run: prospector
-  #     - name: Check import order
-  #       run: isort --check-only mexca --diff

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.9
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
       - name: Python info
         shell: bash -l {0}
         run: |
@@ -65,6 +67,8 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: setup.cfg
       - name: Python info
         shell: bash -l {0}
         run: |

--- a/mexca/core/pipeline.py
+++ b/mexca/core/pipeline.py
@@ -9,8 +9,7 @@ from mexca.audio.integration import AudioIntegrator
 from mexca.core.output import Multimodal
 from mexca.core.preprocessing import Video2AudioConverter
 from mexca.text.sentiment import SentimentExtractor
-from mexca.text.transcription import AudioTextIntegrator
-from mexca.text.transcription import AudioTranscriber
+from mexca.text.transcription import AudioTextIntegrator, AudioTranscriber
 from mexca.video.extraction import FaceExtractor
 
 

--- a/mexca/video/extraction.py
+++ b/mexca/video/extraction.py
@@ -7,8 +7,7 @@ import cv2
 import feat
 import numpy as np
 import torch
-from facenet_pytorch import MTCNN
-from facenet_pytorch import InceptionResnetV1
+from facenet_pytorch import MTCNN, InceptionResnetV1
 from moviepy.editor import VideoFileClip
 from PIL import Image
 from sklearn.metrics.pairwise import cosine_distances

--- a/mexca/video/extraction.py
+++ b/mexca/video/extraction.py
@@ -70,11 +70,12 @@ class FaceExtractor:
 
         if au_model.lower() != 'jaanet':
             raise ValueError('Only the "JAANET" model is available for AU detection')
-        else:
-            self.pyfeat = feat.detector.Detector(
-                au_model=au_model,
-                landmark_model=landmark_model
-            )
+        
+
+        self.pyfeat = feat.detector.Detector(
+            au_model=au_model,
+            landmark_model=landmark_model
+        )
 
 
     def detect(self, frame: np.ndarray) -> Tuple[torch.Tensor, np.ndarray, np.ndarray]:
@@ -285,8 +286,7 @@ class FaceExtractor:
                     # handle edge cases: d1<d2 by definition, but if the clustering that produced
                     # the labels used a different distance definition, this could not be the case.
                     # These edge cases are low in confidence, i.e., c = 0.
-                    if c < 0:
-                        c = 0
+                    c = max(c, 0)
 
                 confidence[i] = c
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ include = mexca, mexca.*
 
 [isort]
 lines_after_imports = 2
-force_single_line = 1
+force_single_line = 0
 no_lines_before = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 known_first_party = mexca
 src_paths = mexca,tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,8 @@ install_requires =
 dev =
     bump2version
     coverage[toml]
-    prospector[with_pyroma]==1.7.0
+    prospector[with_pyroma]==1.7.7
+    pylint==2.15.6
     isort
     pytest
     pytest-cov


### PR DESCRIPTION
Adds a weekly trigger of the build and linting workflow.

Also enables the linting workflow again and specifies installing a specific pylint version.

Adds caching to the Python setup steps.

Triggers the linting job first and only the build jobs if the linting job was successfu.

Changes the `isort` settings to allow for multiple imports from the same package within the same line.