### PR TITLE
Optimize VideoDataset and data loading

### DIFF
--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -38,6 +38,15 @@ class TestVideoDataset:
         assert isinstance(item, dict)
         assert isinstance(item['Image'], torch.Tensor)
         assert item['Frame'] == 0
+        assert len(item['Image'].shape) == 3
+
+
+    def test_getitem_slice(self, video_dataset):
+        item = video_dataset[0:1]
+        assert isinstance(item, dict)
+        assert isinstance(item['Image'], torch.Tensor)
+        assert item['Frame'].shape[0] == 1
+        assert len(item['Image'].shape) == 4
 
 
 class TestFaceExtractor:


### PR DESCRIPTION
Changes the `VideoDataset` class to only load video frames when they are queried. The previous implementation attemped to load the entire video into memory leading to issues. Now, only frames of the current batch are loaded into memory as expected.