### PR TITLE
Fix waveform error

### DIFF
--- a/mexca/pipeline.py
+++ b/mexca/pipeline.py
@@ -174,7 +174,7 @@ class Pipeline:
 
             if self.speaker_identifier or self.voice_extractor:
                 self.logger.debug('Writing audio file')
-                subclip.audio.write_audiofile(audio_path, logger=None, fps=16000)
+                subclip.audio.write_audiofile(audio_path, logger=None, fps=16000, ffmpeg_params=["-ac", "1"])
                 self.logger.info('Wrote audio file to %s', audio_path)
 
         if self.face_extractor:

--- a/mexca/text/sentiment.py
+++ b/mexca/text/sentiment.py
@@ -96,7 +96,7 @@ class SentimentExtractor:
                 begin=sent.begin,
                 end=sent.end,
                 data=SentimentData(
-                    index=sent.data.index,
+                    text=sent.data.text,
                     pos=float(scores[2]),
                     neg=float(scores[0]),
                     neu=float(scores[1])

--- a/mexca/text/transcription.py
+++ b/mexca/text/transcription.py
@@ -138,7 +138,12 @@ class AudioTranscriber:
             audio_sub = audio[start:end]
 
             self.logger.debug('Transcribing segment %s from %s to %s', i, seg.begin, seg.end)
-            output = self.transcriber.transcribe(audio_sub, verbose=None, **asdict(options))
+            try:
+                output = self.transcriber.transcribe(audio_sub, verbose=None, **asdict(options))
+            except RuntimeError as exc:
+                self.logger.error('Audio waveform too short to be transcribed: %s', exc)
+                continue
+
             self.logger.debug('Detected language: %s', whisper.tokenizer.LANGUAGES[output['language']].title())
             segment_text = output['text'].strip()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,8 @@
 
 import os
 import pytest
-from mexca.data import AudioTranscription, Multimodal, SentimentAnnotation, SpeakerAnnotation, VideoAnnotation, VoiceFeatures
+from intervaltree import Interval, IntervalTree
+from mexca.data import AudioTranscription, Multimodal, SegmentData, SentimentAnnotation, SentimentData, SpeakerAnnotation, TranscriptionData, VideoAnnotation, VoiceFeatures
 from mexca.utils import str2bool, optional_int, optional_float, optional_str, bool_or_str, _validate_multimodal
 
 
@@ -33,31 +34,73 @@ def test_bool_or_stri():
     assert bool_or_str("Apple") == "Apple"
 
 
-def test_validate_multimodal():
-    ref_dir = os.path.join('tests', 'reference_files')
-    filepath = 'test_video_audio_5_seconds.mp4'
-    multimodal = Multimodal(
+@pytest.fixture
+def ref_dir():
+    return os.path.join('tests', 'reference_files')
+
+
+@pytest.fixture
+def filepath():
+    return 'test_video_audio_5_seconds.mp4'
+
+
+@pytest.fixture
+def video_annotation(ref_dir) -> VideoAnnotation:
+    return VideoAnnotation.from_json(
+        os.path.join(ref_dir, 'test_video_audio_5_seconds_video_annotation.json')
+    )
+
+
+@pytest.fixture
+def audio_annotation(filepath) -> SpeakerAnnotation:
+    return SpeakerAnnotation([
+        Interval(begin=1.92, end=2.92, data=SegmentData(filename=filepath, channel=0, name=0)),
+        Interval(begin=3.86, end=4.87, data=SegmentData(filename=filepath, channel=0, name=0))
+    ])
+
+
+@pytest.fixture
+def voice_features(ref_dir) -> VoiceFeatures:
+    return VoiceFeatures.from_json(
+        os.path.join(ref_dir, 'test_video_audio_5_seconds_voice_features.json')
+    )
+
+
+@pytest.fixture
+def transcription(filepath) -> AudioTranscription:
+    return AudioTranscription(
+        filename=filepath,
+        subtitles=IntervalTree([
+            Interval(begin=2.00, end=2.41, data=TranscriptionData(index=0, text='Thank you, honey.', speaker='0')),
+            Interval(begin=4.47, end=4.67, data=TranscriptionData(index=1, text='I, uh...', speaker='0'))
+        ])
+    )
+
+
+@pytest.fixture
+def sentiment() -> SentimentAnnotation:
+    return SentimentAnnotation([
+        Interval(begin=2.00, end=2.41, data=SentimentData(text='Thank you, honey.', pos=0.88, neg=0.02, neu=0.1)),
+        Interval(begin=4.47, end=4.67, data=SentimentData(text='I, uh...', pos=0.1, neg=0.37, neu=0.53))
+    ])
+
+
+@pytest.fixture
+def multimodal(filepath, video_annotation, audio_annotation, voice_features, transcription, sentiment) -> Multimodal:
+    return Multimodal(
         filename=filepath,
         duration=5.0,
         fps=25,
         fps_adjusted=5,
-        video_annotation=VideoAnnotation.from_json(
-            os.path.join(ref_dir, 'test_video_audio_5_seconds_video_annotation.json')
-        ),
-        audio_annotation=SpeakerAnnotation.from_rttm(
-            os.path.join(ref_dir, 'test_video_audio_5_seconds_audio_annotation.rttm')
-        ),
-        voice_features=VoiceFeatures.from_json(
-            os.path.join(ref_dir, 'test_video_audio_5_seconds_voice_features.json')
-        ),
-        transcription=AudioTranscription.from_srt(
-            os.path.join(ref_dir, 'test_video_audio_5_seconds_transcription.srt')
-        ),
-        sentiment=SentimentAnnotation.from_json(
-            os.path.join(ref_dir, 'test_video_audio_5_seconds_sentiment.json')
-        )
+        video_annotation=video_annotation,
+        audio_annotation=audio_annotation,
+        voice_features=voice_features,
+        transcription=transcription,
+        sentiment=sentiment
     )
 
+
+def test_validate_multimodal(multimodal):
     multimodal.merge_features()
 
     _validate_multimodal(multimodal)


### PR DESCRIPTION
- Fixes an ffmpeg error in stable-ts that occurs when speech segments are shorter than the hard-coded precision, leading to a waveform with 0 width
- Temporary audio files are now written as mono for compatibility with pretrained models
- Merges the sentiment data with the transcription data using two separate data frames based on frame and text
- Removes the 'index' attribute from the `SentimentData` class and adds a 'text' attribute
- Refactors the tests for the data module with fixtures and hard coded speaker, transcription, and sentiment data instead of reference files