### PR TITLE
Restrict stable-ts version and add "all" extra requirements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Upgrade pip and install dependencies
         run: |
           python3 -m pip install --upgrade pip setuptools wheel
-          python3 -m pip install .[vid,spe,voi,tra,sen,dev]
+          python3 -m pip install .[all,dev]
       - name: Check style against standards using prospector
         run: prospector
       - name: Check import order
@@ -78,7 +78,7 @@ jobs:
       - name: Upgrade pip and install dependencies
         run: |
           python3 -m pip install --upgrade pip setuptools wheel
-          python3 -m pip install .[vid,spe,voi,tra,sen,dev,publishing]
+          python3 -m pip install .[all,dev,publishing]
       - name: Run unit tests
         env:
           HF_TOKEN: ${{secrets.HF_TOKEN }} # Needed for Hugging Face authentication to download pyannote.audio models

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip setuptools wheel
-          python3 -m pip install .[vid,spe,voi,tra,sen,dev]
+          python3 -m pip install .[all,dev]
       - name: Check style against standards using prospector
         run: prospector --zero-exit --output-format grouped --output-format pylint:pylint-report.txt
       - name: Run unit tests with coverage

--- a/docs/installation_details.rst
+++ b/docs/installation_details.rst
@@ -84,6 +84,12 @@ The abbreviations indicate:
 * `tra`: AudioTranscriber
 * `sen`: SentimentExtractor
 
+All five components can be installed via:
+
+.. code-block:: console
+
+    pip install mexca[all]
+
 .. note::
 
     It is also possible to run some pipeline components with containers and others without.

--- a/docs/quick_installation.rst
+++ b/docs/quick_installation.rst
@@ -52,6 +52,12 @@ The abbreviations indicate:
 * `tra`: AudioTranscriber
 * `sen`: SentimentExtractor
 
+All five components can be installed via:
+
+.. code-block:: console
+
+    pip install mexca[all]
+
 To run the demo and example notebooks, install the Jupyter requirements via:
 
 .. code-block:: console

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ voi =
     praat-parselmouth==0.4.1
 tra =
     openai-whisper
-    stable-ts
+    stable-ts==1.0.3
     torch==1.12.0
 sen =
     protobuf==3.20
@@ -77,6 +77,7 @@ sen =
     sentencepiece
     torch==1.12.0
     transformers==4.19.2
+all = mexca[vid,spe,voi,tra,sen]
 demo =
     ipywidgets
     pyyaml


### PR DESCRIPTION
Restricts the version of stable-ts to 1.0.3 until issue with Python 3.7 is fixed.
Adds extra requirements called `all` that combines the component requirements. 