### PR TITLE
Add argument for maximum frames in clustering

### DIFF
--- a/mexca/video.py
+++ b/mexca/video.py
@@ -312,7 +312,7 @@ class FaceExtractor:
         See `spectralcluster <https://wq2012.github.io/SpectralCluster/>`_ for details.
         """
         if not self._clusterer:
-            self._clusterer = SpectralClusterer( #pylint: disable=unexpected-keyword-arg
+            self._clusterer = SpectralClusterer(
                 min_clusters=self.num_faces,
                 max_clusters=self.num_faces,
                 max_spectral_size=self.max_cluster_frames

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ console_scripts =
 vid =
     facenet-pytorch==2.5.2
     py-feat==0.5.0
-    spectralcluster==0.2.5
+    spectralcluster==0.2.16
     torch==1.12.0
     torchvision==0.13.0
 spe =


### PR DESCRIPTION
Adds an extra argument to the FaceExtractor component which allows setting a maximum number of frames that are used for spectral clustering. This is useful for longer videos where a large number of frames need to be clustered to prevent out-of-memory issues.