### PR TITLE
Refactor container test workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,82 +15,114 @@ jobs:
   build:
     name: Build Docker containers
     runs-on: ubuntu-latest
-    # strategy:
-    #   matrix:
-    #     component: ["face-extractor", "speaker-identifier", "voice-extractor", "audio-transcriber", "sentiment-extractor"]
-    env:
-      version: v0.5.0
+    strategy:
+      matrix:
+        component: ["face-extractor", "speaker-identifier", "voice-extractor", "audio-transcriber", "sentiment-extractor"]
     steps:
-      - name: Checkout
+      -
+        name: Checkout
         uses: actions/checkout@v3
-      - name: Get branch name
+      -
+        name: Get branch name
         id: branch-name
         uses: tj-actions/branch-names@v6
-      - name: Set up Docker Buildx
+      -
+        name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Build FaceExtractor
-        uses: docker/build-push-action@v3
+      -
+        name: Cache Docker layers
+        uses: actions/cache@v3
         with:
-          build-args: branch=${{ steps.branch-name.outputs.current_branch }}
-          context: ./docker/face-extractor
-          load: true
-          push: false
-          no-cache: true
-          tags: mexca/face-extractor:${{env.version}}
-      - name: Build SpeakerIdentifier
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-${{ matrix.component }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.component }}-buildx-
+      -
+        name: Build component from main as 'latest' tag and export
         uses: docker/build-push-action@v3
+        # if: github.event_name == 'workflow_dispatch'
         with:
           build-args: |
-            HF_TOKEN=${{secrets.HF_TOKEN }}
+            HF_TOKEN=${{ secrets.HF_TOKEN }}
             branch=${{ steps.branch-name.outputs.current_branch }}
-          context: ./docker/speaker-identifier
+          context: ./docker/${{ matrix.component }}
           load: true
           push: false
-          no-cache: true
-          tags: mexca/speaker-identifier:${{env.version}}
-      - name: Build VoiceExtractor
-        uses: docker/build-push-action@v3
+          tags: mexca/${{ matrix.component }}:latest
+          outputs: type=docker,dest=/tmp/${{ matrix.component }}.tar
+      -
+        name: Upload artifact
+        uses: actions/upload-artifact@v3
         with:
-          build-args: branch=${{ steps.branch-name.outputs.current_branch }}
-          context: ./docker/voice-extractor
-          load: true
-          push: false
-          no-cache: true
-          tags: mexca/voice-extractor:${{env.version}}
-      - name: Build AudioTranscriber
-        uses: docker/build-push-action@v3
+          name: ${{ matrix.component }}
+          path: /tmp/${{ matrix.component }}.tar
+
+  use:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Download FaceExtractor artifact
+        uses: actions/download-artifact@v3
         with:
-          build-args: branch=${{ steps.branch-name.outputs.current_branch }}
-          context: ./docker/audio-transcriber
-          load: true
-          push: false
-          no-cache: true
-          tags: mexca/audio-transcriber:${{env.version}}
-      - name: Build SentimentExtractor
-        uses: docker/build-push-action@v3
+          name: face-extractor
+          path: /tmp
+      -
+        name: Download SpeakerIdentifier artifact
+        uses: actions/download-artifact@v3
         with:
-          build-args: branch=${{ steps.branch-name.outputs.current_branch }}
-          context: ./docker/sentiment-extractor
-          load: true
-          push: false
-          no-cache: true
-          tags: mexca/sentiment-extractor:${{env.version}}
-      - name: Set up Python 3.9
+          name: speaker-identifier
+          path: /tmp
+      -
+        name: Download VoiceExtractor artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: voice-extractor
+          path: /tmp
+      -
+        name: Download AudioTranscriber artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: audio-transcriber
+          path: /tmp
+      -
+        name: Download SentimentExtractor artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: sentiment-extractor
+          path: /tmp
+      -
+        name: Load images
+        run: |
+          docker load --input /tmp/face-extractor.tar
+          docker load --input /tmp/speaker-identifier.tar
+          docker load --input /tmp/voice-extractor.tar
+          docker load --input /tmp/audio-transcriber.tar
+          docker load --input /tmp/sentiment-extractor.tar
+          docker image ls -a
+      -
+        name: Set up Python 3.9
         uses: actions/setup-python@v3
         with:
           python-version: "3.9"
           cache: 'pip'
           cache-dependency-path: setup.cfg
-      - name: Python info
+      -
+        name: Python info
         shell: bash -l {0}
         run: |
           which python3
           python3 --version
-      - name: Upgrade pip and install dependencies
+      -
+        name: Upgrade pip and install dependencies
         run: |
           python3 -m pip install --upgrade pip setuptools wheel
           python3 -m pip install .[dev]
-      - name: Run container tests
+      -
+        name: Run container tests
         env:
-          HF_TOKEN: ${{secrets.HF_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: pytest -vv tests/test_container.py

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,59 +51,6 @@ jobs:
           tags: mexca/${{ matrix.component }}:latest
           outputs: type=docker,dest=/tmp/${{ matrix.component }}.tar
       -
-        name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.component }}
-          path: /tmp/${{ matrix.component }}.tar
-
-  use:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      -
-        name: Download FaceExtractor artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: face-extractor
-          path: /tmp
-      -
-        name: Download SpeakerIdentifier artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: speaker-identifier
-          path: /tmp
-      -
-        name: Download VoiceExtractor artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: voice-extractor
-          path: /tmp
-      -
-        name: Download AudioTranscriber artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: audio-transcriber
-          path: /tmp
-      -
-        name: Download SentimentExtractor artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: sentiment-extractor
-          path: /tmp
-      -
-        name: Load images
-        run: |
-          docker load --input /tmp/face-extractor.tar
-          docker load --input /tmp/speaker-identifier.tar
-          docker load --input /tmp/voice-extractor.tar
-          docker load --input /tmp/audio-transcriber.tar
-          docker load --input /tmp/sentiment-extractor.tar
-          docker image ls -a
-      -
         name: Set up Python 3.9
         uses: actions/setup-python@v3
         with:
@@ -125,4 +72,4 @@ jobs:
         name: Run container tests
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: pytest -vv tests/test_container.py
+        run: pytest -vv tests/test_container.py -E ${{ matrix.component }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,9 +38,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.component }}-buildx-
       -
-        name: Build component from main as 'latest' tag and export
+        name: Build component from main as 'latest' tag
         uses: docker/build-push-action@v3
-        # if: github.event_name == 'workflow_dispatch'
         with:
           build-args: |
             HF_TOKEN=${{ secrets.HF_TOKEN }}
@@ -49,7 +48,6 @@ jobs:
           load: true
           push: false
           tags: mexca/${{ matrix.component }}:latest
-          outputs: type=docker,dest=/tmp/${{ matrix.component }}.tar
       -
         name: Set up Python 3.9
         uses: actions/setup-python@v3

--- a/mexca/audio/__init__.py
+++ b/mexca/audio/__init__.py
@@ -9,7 +9,7 @@ if importlib.util.find_spec("pyannote") is not None:
     from .identification import SpeakerIdentifier
 
     all.append("SpeakerIdentifier")
-if importlib.util.find_spec("librosa") is not None:
+if importlib.util.find_spec("emvoice") is not None:
     from .extraction import VoiceExtractor
 
     all.append("VoiceExtractor")

--- a/mexca/audio/extraction.py
+++ b/mexca/audio/extraction.py
@@ -789,7 +789,7 @@ def cli():
 
     args = parser.parse_args().__dict__
 
-    if "config" in args:
+    if isinstance(args["config"], str) and os.path.exists(args["config"]):
         config = VoiceFeaturesConfig.from_yaml(args["config"])
     else:
         config = VoiceFeaturesConfig()

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -23,16 +23,10 @@ from mexca.data import (
 )
 
 
-@pytest.mark.skip_env("runner")
 class TestBaseContainer:
     def test_invalid_image_name(self):
         with pytest.raises(NotFound):
             BaseContainer(image_name="sdfsdf")
-
-    def test_get_latest_tag(self):
-        container = VoiceExtractorContainer(get_latest_tag=True)
-        assert isinstance(container, VoiceExtractorContainer)
-        assert container.image_name == "mexca/voice-extractor:latest"
 
 
 @pytest.mark.run_env("face-extractor")
@@ -65,7 +59,9 @@ class TestSpeakerIdentifierContainer:
     @pytest.fixture
     def speaker_identifier(self):
         return SpeakerIdentifierContainer(
-            num_speakers=self.num_speakers, get_latest_tag=True
+            num_speakers=self.num_speakers,
+            use_auth_token=os.environ["HF_TOKEN"],
+            get_latest_tag=True,
         )
 
     def test_apply(self, speaker_identifier):
@@ -76,7 +72,7 @@ class TestSpeakerIdentifierContainer:
 @pytest.mark.run_env("voice-extractor")
 class TestVoiceExtractorContainer:
     filepath = os.path.join(
-        "tests", "test_files", "test_video_audio_5_seconds.mp4"
+        "tests", "test_files", "test_video_audio_5_seconds.wav"
     )
     num_faces = 2
 


### PR DESCRIPTION
Fixes the import of the `VoiceExtractor` class for the `VoiceExtractorContainer` when only `mexca[voi]` is installed.
Fixes the container tests to be independent for each component.
Fixes the container test workflow to run tests independently for each component.
Fixes the saving and loading of intermediate files in the container components.