### PR TITLE
Change MEFARG model to be loaded from Hugging Face Hub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,14 +56,13 @@ jobs:
         python-version: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v3
-      - name: Download libsndfile and ffmpeg
+      - name: Download libsndfile
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install --fix-missing libsndfile-dev ffmpeg
-      - name: Download ffmpeg
-        if: matrix.os == 'macos-latest'
-        run: brew install ffmpeg
+          sudo apt-get install --fix-missing libsndfile-dev
+      - name: Setup FFmpeg
+        uses: federicocarboni/setup-ffmpeg@v3.1
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:

--- a/mexca/video/mefarg.py
+++ b/mexca/video/mefarg.py
@@ -12,11 +12,10 @@ Code adapted from the `OpenGraphAU <https://github.com/lingjivoo/OpenGraphAU/tre
 """
 
 import logging
-import os
-from collections import OrderedDict
+from typing import Dict
 
-import gdown
 import torch
+from huggingface_hub import PyTorchModelHubMixin
 from torch import nn
 from torchvision.models import ResNet50_Weights, resnet50
 
@@ -24,17 +23,17 @@ from mexca.video.helper_classes import LinearBlock
 from mexca.video.mefl import MEFL
 
 
-class MEFARG(nn.Module):
+class MEFARG(nn.Module, PyTorchModelHubMixin):
     """Apply a multi-dimensional edge feature-based action unit (AU) relation graph (MEFARG) model.
 
     Predict activations of 27 main and 14 sub AUs from representations of a face image.
 
     Parameters
     ----------
-    n_main_aus: int, default=27
-        Number of main AUs.
-    n_sub_aus: int, default=14
-        Number of sub AUs.
+    config: dict
+        Configuration dict of the model with two keys:
+        `n_main_aus` is the number of main and `n_sub_aus` is the number of sub AUs to be predicted.
+        If pretrained model weights are loaded, these must match the configuration.
 
     Notes
     -----
@@ -43,7 +42,7 @@ class MEFARG(nn.Module):
 
     """
 
-    def __init__(self, n_main_aus=27, n_sub_aus=14):
+    def __init__(self, config: Dict):
         super().__init__()
         self.logger = logging.getLogger("mexca.video.MEFARG")
         self.backbone = resnet50(weights=ResNet50_Weights.DEFAULT)
@@ -57,65 +56,9 @@ class MEFARG(nn.Module):
         self.linear_global = LinearBlock(
             self.n_in_channels, self.n_out_channels
         )
-        self.head = MEFL(self.n_out_channels, n_main_aus, n_sub_aus)
-
-    @classmethod
-    def from_pretrained(cls, device: torch.device = torch.device(type="cpu")):
-        """Load a pretrained model.
-
-        If not found, the pretrained model is downloaded from Google Drive and stored in the PyTorch cache.
-
-        Parameters
-        ----------
-        device: torch.device, default=torch.device(type='cpu')
-            Device on which the model is loaded.
-
-        """
-        # Init class instance
-        model = cls()
-
-        model_id = "1UMnpbj_YKlqHF1m0DHV0KYD3qmcOmeXp"
-
-        # Store pretraned model int PyTorch cache
-        model_path = os.path.join(torch.hub.get_dir(), f"mefarg-{model_id}.pth")
-
-        # Download model from Google Drive
-        if not os.path.exists(model_path):
-            url = f"https://drive.google.com/uc?&id={model_id}&confirm=t"
-            model.logger.info("Downloading pretrained model from %s", url)
-            gdown.download(url, output=model_path)
-            model.logger.info("Pretrained model saved at %s", model_path)
-
-        # Load pretrained state dict to device
-        checkpoint = torch.load(model_path, map_location=device)
-
-        # Replace state dict keys with correct model attribute names
-        new_state_dict = OrderedDict()
-
-        replace_dict = {
-            "global_linear": "linear_global",
-            "U": "linear_u",
-            "V": "linear_v",
-            "B": "linear_b",
-            "E": "linear_e",
-            "FAM": "fam",
-            "ARM": "arm",
-            "A": "linear_a",
-            "head.main_class_linears": "head.main_node_linear_layers",
-        }
-
-        for state_k, state_v in checkpoint["state_dict"].items():
-            if "module." in state_k:
-                state_k = state_k[7:]  # Remove `module.` from keys
-
-            for rep_k, rep_v in replace_dict.items():
-                state_k = state_k.replace(rep_k, rep_v)
-
-            new_state_dict[state_k] = state_v
-
-        model.load_state_dict(new_state_dict, strict=True)
-
-        return model
+        self.head = MEFL(
+            self.n_out_channels, config["n_main_aus"], config["n_sub_aus"]
+        )
 
     def _backbone_forward(self, x: torch.Tensor) -> torch.Tensor:
         # Perform forward pass of backbone without last FC layer

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ console_scripts =
 
 [options.extras_require]
 vid =
-    facenet-pytorch==2.5.2
+    facenet-pytorch==2.5.3
     av==10.0
     huggingface-hub==0.17.3
     scikit-learn==1.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,8 +60,8 @@ console_scripts =
 [options.extras_require]
 vid =
     facenet-pytorch==2.5.2
-    gdown==4.6.0
     av==10.0
+    huggingface-hub==0.17.3
     scikit-learn==1.3.1
     spectralcluster==0.2.16
     torch>=2.0

--- a/tests/test_video_mefarg.py
+++ b/tests/test_video_mefarg.py
@@ -12,17 +12,22 @@ class TestMEFARG:
     n_main_nodes = 27
     n_sub_nodes = 14
     n_batch = 1
+    model_id = "mexca/mefarg-open-graph-au-resnet50-stage-2"
 
     @pytest.fixture
     def inputs(self):
         return torch.rand((1, 3, self.in_features, self.in_features))
 
     @pytest.fixture
-    def mefarg(self):
-        return MEFARG(self.n_main_nodes, self.n_sub_nodes)
+    def config(self):
+        return {"n_main_aus": self.n_main_nodes, "n_sub_aus": self.n_sub_nodes}
+
+    @pytest.fixture
+    def mefarg(self, config):
+        return MEFARG(config)
 
     def test_from_pretrained(self):
-        model = MEFARG.from_pretrained()
+        model = MEFARG.from_pretrained(self.model_id)
         assert isinstance(model, MEFARG)
 
     def test_forward(self, mefarg, inputs):


### PR DESCRIPTION
Changes the `MEFARG` class to inherit from `PyTorchModelHubMixin` to load a pretrained model from Hugging Face Hub instead of Google Drive. This should be make loading the model more stable.

Updates facenet-pytorch to 2.5.3 to fix numpy deprecation warning.