### PR TITLE
Add 'num_faces' face selection option

### DIFF
--- a/mexca/video/extraction.py
+++ b/mexca/video/extraction.py
@@ -507,10 +507,15 @@ class FaceExtractor:
 
             frm = transform(frm)
 
-            with torch.no_grad():
-                aus = self.extractor(frm.to(self.device))
-
-            aus_list.append(aus.detach().cpu().numpy())
+            try:
+                with torch.no_grad():
+                    aus = self.extractor(frm.to(self.device))
+                    aus_list.append(aus.detach().cpu().numpy())
+            except Exception as exc:
+                self.logger.exception(
+                    "Exception in action unit extraction: %s", exc
+                )
+                aus_list.append(None)
 
         return np.array(aus_list)
 

--- a/mexca/video/extraction.py
+++ b/mexca/video/extraction.py
@@ -194,8 +194,9 @@ class FaceExtractor:
     select_largest : bool, default=True
         Whether to return the largest face or the one with the highest probability
         if multiple faces are detected.
-    selection_method : {None, 'probability', 'largest', 'largest_over_threshold', 'center_weighted_size'}, optional, default=None
+    selection_method : {None, 'num_faces', 'probability', 'largest', 'largest_over_threshold', 'center_weighted_size'}, optional, default='num_faces'
         The heuristic used for selecting detected faces. If not `None`, overrides `select_largest`.
+        The default `num_faces`, selects a maximum of `num_faces` faces per frame.
     keep_all: bool, default=True
         Whether all faces should be returned in the order of `select_largest`.
     device: torch.device, optional, default=torch.device("cpu")
@@ -225,7 +226,7 @@ class FaceExtractor:
         factor: float = 0.709,
         post_process: bool = True,
         select_largest: bool = True,
-        selection_method: Optional[str] = None,
+        selection_method: Optional[str] = "num_faces",
         keep_all: bool = True,
         device: torch.device = torch.device(type="cpu"),
         max_cluster_frames: Optional[int] = None,
@@ -275,7 +276,10 @@ class FaceExtractor:
                 factor=self.factor,
                 post_process=self.post_process,
                 select_largest=self.select_largest,
-                selection_method=self.selection_method,
+                # 'num_faces' is applied in detection method
+                selection_method=None
+                if self.selection_method == "num_faces"
+                else self.selection_method,
                 keep_all=self.keep_all,
                 device=self.device,
             )
@@ -406,6 +410,31 @@ class FaceExtractor:
 
         self.logger.debug("Detecting faces and facial landmarks")
         boxes, probs, landmarks = self.detector.detect(frame, landmarks=True)
+
+        # Select only the first 'num_faces'
+        if self.selection_method and self.selection_method == "num_faces":
+            if isinstance(boxes, list) or (
+                isinstance(boxes, np.ndarray) and len(boxes.shape) == 1
+            ):
+                boxes = [
+                    box[: self.num_faces, :] if box is not None else None
+                    for box in boxes
+                ]
+                probs = [
+                    prob[: self.num_faces] if prob is not None else None
+                    for prob in probs
+                ]
+                landmarks = [
+                    lmk[: self.num_faces, :] if lmk is not None else None
+                    for lmk in landmarks
+                ]
+            elif (
+                isinstance(boxes, np.ndarray)
+                and boxes.shape[1] > self.num_faces
+            ):
+                boxes = boxes[:, : self.num_faces, :]
+                probs = probs[:, : self.num_faces]
+                landmarks = landmarks[:, : self.num_faces, :, :]
 
         self.logger.debug("Extracting faces")
         faces = self.detector.extract(frame, boxes, save_path=None)

--- a/tests/test_video_extraction.py
+++ b/tests/test_video_extraction.py
@@ -325,3 +325,38 @@ class TestFaceExtractor:
         )
         assert os.path.exists(out_filename)
         os.remove(out_filename)
+
+
+class TestFaceExtractorMaxFaces:
+    filepath = os.path.join(
+        "tests", "test_files", "test_video_multi_5_frames.mp4"
+    )
+
+    dataset = VideoDataset(filepath, skip_frames=1)
+    data_loader = DataLoader(dataset, batch_size=1)
+
+    @pytest.fixture
+    def extractor(self):
+        return FaceExtractor(
+            num_faces=2, selection_method="num_faces"
+        )  # This is actually now the default
+
+    def test_detect_num_faces(self, extractor):
+        image = self.dataset[0:5]["Image"]
+        faces, boxes, probs, landmarks = extractor.detect(image)
+
+        assert (
+            isinstance(boxes, np.ndarray)
+            and boxes.shape[1] == extractor.num_faces
+        )
+        assert (
+            isinstance(probs, np.ndarray)
+            and probs.shape[1] == extractor.num_faces
+        )
+        assert (
+            isinstance(landmarks, np.ndarray)
+            and landmarks.shape[1] == extractor.num_faces
+        )
+        assert isinstance(faces, list) and np.all(
+            [face.shape[0] == extractor.num_faces for face in faces]
+        )


### PR DESCRIPTION
Adds a statement to catch errors in `MEFARG.foward()` (e.g., GPU memory issues), so that the pipeline can continue if such errors only occurr for a single frame.

Adds a new method for selecting faces for each frame: The maximum number is the number of faces used by the clusterer. This is now the default method because it seems this is what most users would want.