### PR TITLE
Add kmeans clustering and switch to sklearn clustering

### DIFF
--- a/mexca/container.py
+++ b/mexca/container.py
@@ -121,7 +121,6 @@ class FaceExtractorContainer(BaseContainer):
         selection_method: Optional[str] = None,
         keep_all: bool = True,
         device: Optional["torch.device"] = "cpu",
-        max_cluster_frames: Optional[int] = None,
         embeddings_model: str = "vggface2",
         image_name: str = "mexca/face-extractor",
         get_latest_tag: bool = False,
@@ -135,7 +134,6 @@ class FaceExtractorContainer(BaseContainer):
         self.selection_method = selection_method
         self.keep_all = keep_all
         self.device = device
-        self.max_cluster_frames = max_cluster_frames
         self.embeddings_model = embeddings_model
 
         super().__init__(image_name=image_name, get_latest_tag=get_latest_tag)
@@ -178,8 +176,6 @@ class FaceExtractorContainer(BaseContainer):
             self.keep_all,
             "--device",
             self.device,
-            "--max-cluster-frames",
-            self.max_cluster_frames,
             "--embeddings-model",
             self.embeddings_model,
         ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,6 @@ vid =
     av==10.0
     huggingface-hub==0.17.3
     scikit-learn==1.3.1
-    spectralcluster==0.2.16
     torch>=2.0
 spe =
     pyannote.audio==3.1.1

--- a/tests/test_video_extraction.py
+++ b/tests/test_video_extraction.py
@@ -9,7 +9,8 @@ import numpy as np
 import pytest
 import torch
 from facenet_pytorch import MTCNN, InceptionResnetV1
-from spectralcluster import SpectralClusterer
+from sklearn.base import ClusterMixin
+from sklearn.cluster import KMeans, SpectralClustering
 from torch.utils.data import DataLoader
 
 from mexca.data import EMPTY_VALUE, VideoAnnotation
@@ -88,7 +89,7 @@ class TestFaceExtractor:
 
         assert isinstance(extractor.detector, MTCNN)
         assert isinstance(extractor.encoder, InceptionResnetV1)
-        assert isinstance(extractor.clusterer, SpectralClusterer)
+        assert isinstance(extractor.clusterer, ClusterMixin)
         assert isinstance(extractor.extractor, MEFARG)
 
         del extractor.detector
@@ -127,6 +128,24 @@ class TestFaceExtractor:
         assert embeddings.shape == (1, 512)
 
     def test_identify(self, extractor):
+        n_samples = 10
+        embeddings = np.random.uniform(0, 1, size=(n_samples, 512))
+        labels = extractor.identify(embeddings)
+        assert labels.shape == (n_samples,)
+
+    def test_identify_spectral(self):
+        extractor = FaceExtractor(
+            num_faces=None, clusterer=SpectralClustering(n_clusters=4)
+        )
+        n_samples = 10
+        embeddings = np.random.uniform(0, 1, size=(n_samples, 512))
+        labels = extractor.identify(embeddings)
+        assert labels.shape == (n_samples,)
+
+    def test_identify_kmeans(self):
+        extractor = FaceExtractor(
+            num_faces=None, clusterer=KMeans(n_clusters=4)
+        )
         n_samples = 10
         embeddings = np.random.uniform(0, 1, size=(n_samples, 512))
         labels = extractor.identify(embeddings)


### PR DESCRIPTION
Changes the face clustering backend from `spectralcluster` to `sklearn.cluster` removing `spectralcluster` as a dependency. The results between `spectralcluster.SpectralClusterer` and `sklearn.cluster.SpectralClustering` are very similar.

Also adds a new option `clustering_method` for the `FaceExtractor` class. Allows users to switch from `spectral` (default) to `kmeans` using `sklearn.cluster.KMeans`. For large datasets, this can be very beneficial because spectral clustering often runs into memory issues (because it needs to compute and affinity matrix and eigenvectors). kmeans is also much faster.